### PR TITLE
fix: emit `OperatorVestingFinalizedEvent`, add multiplier validation

### DIFF
--- a/sources/vesting.move
+++ b/sources/vesting.move
@@ -443,7 +443,15 @@ module vip::vesting {
         vector::for_each(
             finalized_keys,
             |stage_key| {
-                table::remove(operator_vestings, stage_key);
+                let vesting = table::remove(operator_vestings, stage_key);
+                event::emit(
+                    OperatorVestingFinalizedEvent {
+                        account: operator_addr,
+                        bridge_id,
+                        version,
+                        start_stage: vesting.start_stage,
+                    },
+                );
             },
         );
 

--- a/sources/vip.move
+++ b/sources/vip.move
@@ -240,6 +240,7 @@ module vip::vip {
         minimum_score_ratio: BigDecimal,
     }
 
+    // DEPRECATED
     #[event]
     struct ReleaseTimeUpdateEvent has drop, store {
         stage: u64,

--- a/sources/weight_vote.move
+++ b/sources/weight_vote.move
@@ -201,6 +201,12 @@ module vip::weight_vote {
             module_store.voting_period < module_store.cycle_interval,
             error::invalid_argument(EINVALID_PARAMETER),
         );
+
+        // check lock period multiplier
+        assert!(
+            module_store.min_lock_period_multiplier <= module_store.max_lock_period_multiplier,
+            error::invalid_argument(EINVALID_PARAMETER),
+        );
     }
 
     public entry fun update_pair_multiplier(


### PR DESCRIPTION
- emit `OperatorVestingFinalizedEvent`
- mark `ReleaseTimeUpdateEvent` deprecated
- add lock period multiplier checker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced vesting tracking with new event notifications that provide detailed finalization information.
	- Introduced a new (deprecated) event for release time updates in the staking mechanism.
  
- **Bug Fixes**
	- Improved parameter validation to ensure proper lock period configurations, reducing the chance of invalid settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->