### PR TITLE
feat: add `get_pair_multipliers` view function

### DIFF
--- a/sources/weight_vote.move
+++ b/sources/weight_vote.move
@@ -728,6 +728,18 @@ module vip::weight_vote {
         }
     }
 
+    #[view]
+    public fun get_pair_multipliers(metadata: vector<Object<Metadata>>): vector<BigDecimal> {
+        let module_store = borrow_global<ModuleStore>(@vip);
+        vector::map_ref(&metadata, |metadata| {
+            *table::borrow_with_default(
+                &module_store.pair_multipliers,
+                *metadata,
+                &bigdecimal::one(),
+            )
+        })
+    }
+
     inline fun use_weight(_v: Weight) {}
 
     #[test_only]


### PR DESCRIPTION
Add `get_pair_multipliers` view function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new capability that allows users to retrieve associated multipliers for multiple metadata entries in a single operation, enhancing efficiency and streamlining data access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->