### PR TITLE
feat: unlock reentry check when hook executed

### DIFF
--- a/sources/lock_staking.move
+++ b/sources/lock_staking.move
@@ -79,7 +79,7 @@ module vip::lock_staking {
 
     struct StakingAccount has key {
         extend_ref: ExtendRef,
-        last_height: u64, // record the last executed height to prevent the stargate sequential problem.
+        last_height: u64, // record the locked height to prevent the stargate sequential problem.
         validators: Table<String, u16>, // validator => number of delegation
         delegations: Table<DelegationKey, BigDecimal>, // key => locked share
         // This share variable is specific to the lock_staking.move module


### PR DESCRIPTION
- Rename `assert_height` to `reentry_check`
- To allow multiple calls in same height, unlock when hook executed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a mechanism to reset account status, improving transitions during staking operations.
  - Introduced a new function to check and manage re-entrancy in staking accounts.

- **Refactor**
  - Enhanced validation checks for staking processes to prevent re-entrancy issues and improve overall reliability.
  - Updated function signatures and constants to better reflect new functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->