### PR TITLE
fix: make mock_staking as test_only module

### DIFF
--- a/sources/mock/mstaking.move
+++ b/sources/mock/mstaking.move
@@ -1,4 +1,4 @@
-
+#[test_only]
 module initia_std::mock_mstaking {
     use std::signer;
     use std::vector;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated our internal module configuration to clearly mark a component used exclusively for testing. This change helps distinguish testing components from production code. As part of our ongoing efforts to streamline development processes, no user-facing features were altered and overall functionality remains unaffected. Please note that this is an entirely internal update and will not impact your experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->