### PR TITLE
feat: add rollup challenge

### DIFF
--- a/sources/vip.move
+++ b/sources/vip.move
@@ -1118,8 +1118,6 @@ module vip::vip {
         );
 
         // delete snapshot data
-        let stage_key = table_key::encode_u64(challenge_stage);
-
         let stage_data =
             table::borrow_mut(
                 &mut module_store.stage_data,

--- a/sources/vip.move
+++ b/sources/vip.move
@@ -270,6 +270,13 @@ module vip::vip {
     }
 
     #[event]
+    struct UpdateScoreContractEvent has drop, store {
+        bridge_id: u64,
+        version: u64,
+        score_contract: string::String
+    }
+
+    #[event]
     struct SubmitSnapshotEvent has drop, store {
         bridge_id: u64,
         version: u64,
@@ -1713,6 +1720,14 @@ module vip::vip {
         assert!(is_registered, error::unavailable(EBRIDGE_NOT_REGISTERED));
         let bridge = load_registered_bridge_mut(module_store, bridge_id, version);
         bridge.vip_l2_score_contract = new_vip_l2_score_contract;
+
+        event::emit(
+            UpdateScoreContractEvent {
+                bridge_id,
+                version,
+                score_contract: new_vip_l2_score_contract,
+            }
+        );
     }
 
     public entry fun update_operator(

--- a/sources/vip.move
+++ b/sources/vip.move
@@ -1028,7 +1028,7 @@ module vip::vip {
         utils::check_chain_permission(chain);
         let module_store = borrow_global_mut<ModuleStore>(@vip);
         assert!(
-            module_store.stage >= challenge_stage,
+            module_store.stage > challenge_stage,
             error::permission_denied(EINVALID_CHALLENGE_STAGE)
         );
         let challenge_period = module_store.challenge_period;
@@ -1103,7 +1103,7 @@ module vip::vip {
         utils::check_chain_permission(chain);
         let module_store = borrow_global_mut<ModuleStore>(@vip);
         assert!(
-            module_store.stage >= challenge_stage,
+            module_store.stage > challenge_stage,
             error::permission_denied(EINVALID_CHALLENGE_STAGE)
         );
         let challenge_period = module_store.challenge_period;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced events to log rollup challenge executions and score contract updates, including bridge ID, version, stage, and contract details.
  - Added a public function enabling authorized users to challenge rollup submissions by removing challenged snapshots with validation and event emission.
  - Enhanced the score contract update function to emit events reflecting changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->